### PR TITLE
Stick to gcc 4.8 to avoid exception errors

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: u-boot-meson
 Section: misc
 Priority: extra
-Build-Depends: quilt (>= 0.46-7~), debhelper (>= 7.0.50~)
+Build-Depends: quilt (>= 0.46-7~), debhelper (>= 7.0.50~), gcc-4.8
 Standards-Version: 3.9.1
 Maintainer: Daniel Drake <drake@endlessm.com>
 

--- a/debian/rules
+++ b/debian/rules
@@ -45,8 +45,8 @@ override_dh_auto_build:
 		mkdir -p debian/build/$$plat; \
 		cp debian/bin/mkbl2 $$PWD/debian/build/$$plat; \
 		$(MAKE) O=$$PWD/debian/build/$$plat $${plat}_config; \
-		test "$$buildtarget" = "-" && $(MAKE) O=$$PWD/debian/build/$$plat; \
-		test "$$buildtarget" != "-" && $(MAKE) O=$$PWD/debian/build/$$plat \
+		test "$$buildtarget" = "-" && $(MAKE) CC=gcc-4.8 O=$$PWD/debian/build/$$plat; \
+		test "$$buildtarget" != "-" && $(MAKE) CC=gcc-4.8 O=$$PWD/debian/build/$$plat \
 			$$PWD/debian/build/$$plat/$$buildtarget; \
 		true; \
 	done <debian/platforms-debs-targets


### PR DESCRIPTION
[endlessm/eos-shell#5447]

Signed-off-by: Carlo Caione carlo@endlessm.com
